### PR TITLE
feat(snowflake): support MFA token caching on snowflake-sdk 1.12.0+ by using connectAsync

### DIFF
--- a/packages/snowflake/src/connection-manager.ts
+++ b/packages/snowflake/src/connection-manager.ts
@@ -58,7 +58,7 @@ export class SnowflakeConnectionManager extends AbstractConnectionManager<
       }) as SnowflakeConnection;
 
       await new Promise<void>((resolve, reject) => {
-        connection.connect(err => {
+        connection.connectAsync(err => {
           if (err) {
             return void reject(err);
           }


### PR DESCRIPTION
Use connectAsync() instead of connect() to enable MFA token caching for snowflake-sdk, which gained this feature in version 1.12.0

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions? _This is the only part that confuses me; does a change like this need new tests, or are the existing ones suitable?_
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? _n/a_
- [x] Did you update the typescript typings accordingly (if applicable)? _n/a_
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->
This implements `connectAsync` in place of `connect`, which is currently required for snowflake-sdk's [newly added support](https://docs.snowflake.com/en/release-notes/clients-drivers/nodejs-2024) for its [multi-factor authentication token caching](https://docs.snowflake.com/en/user-guide/security-mfa#label-mfa-token-caching) feature. 
This is meant to resolve my GitHub issue: https://github.com/sequelize/sequelize/issues/17454

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
(N/a; this doesn't negatively impact non-MFA logins from both my and Snowflake support's tests)